### PR TITLE
Fix credit card checkout

### DIFF
--- a/templates/checkout/credit-card-item.php
+++ b/templates/checkout/credit-card-item.php
@@ -73,6 +73,7 @@ $type              = 'card';
 			data-action="choose-payment"
 			type="radio"
 			name="payment_method"
+            checked="checked"
 			value="credit_card">
 	</div>
 </li>


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Issues        | https://mundipagg.atlassian.net/browse/MOD-659 
| What?         | Fix credit card checkout
| Why?          | Payment method information weren't being sent to background.
| How?          | Add checked attribute to the broken input.